### PR TITLE
Fix for Chat Model Compatibility with v1/chat/completions Endpoint

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -14,6 +14,15 @@ export class ChatGPTClient {
     const { model, maxTokens, temperature } = await getPromptOptions();
 
     try {
+      if (model.includes("gpt-3.5") || model.includes("gpt-4")) {
+        const result = await openai.createChatCompletion({
+          model,
+          messages: [{ role: "user", content: question }],
+          max_tokens: maxTokens,
+          temperature,
+        });
+        return result.data.choices[0].message.content;
+      }
       const result = await openai.createCompletion({
         model,
         prompt: question,


### PR DESCRIPTION
#### Description:

This pull request addresses the issue of using chat models with the **v1/completions** endpoint, which results in an error. The fix ensures compatibility by conditionally using the appropriate OpenAI API endpoint based on the model type. This change resolves GitHub issue [#43](https://github.com/your-repository/issues/43).

#### Issue Reference:
- **Issue:** This is a chat model and not supported in the v1/completions endpoint. Did you mean to use v1/chat/completions? [#43](https://github.com/your-repository/issues/43)
- **Error Message:**
```json
{
  "data": {
    "error": {
      "message": "This is a chat model and not supported in the v1/completions endpoint. Did you mean to use v1/chat/completions?",
      "type": "invalid_request_error",
      "param": "model",
      "code": null
    }
  }
}
```
#### Config:
```json
{
  "model": "gpt-3.5-turbo",
  "temperature": 0.5,
  "maxTokens": 2048
}
```
#### Changes Made:
Refactored **ChatGPTClient** class to handle both chat and completion models:
  - Added conditional logic to check if the model is a chat model (**gpt-3.5-turbo**, **gpt-4**, etc.).
  - Used the **createChatCompletion** method for chat models.
  - Used the **createCompletion** method for completion models.

#### Testing:
Tested with both chat models (**gpt-3.5-turbo**, **gpt-4**) and completion models (**davinci**, **curie**, etc.) to ensure the correct endpoint is used and responses are handled appropriately.

This fix will ensure that chat models will no longer produce the "not supported" error by using the appropriate **v1/chat/completions** endpoint.

Please review and merge this pull request to resolve issue #43.
